### PR TITLE
SRE-1401: path-to-regexp update 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3680,9 +3680,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="
     },
     "node_modules/pathval": {
       "version": "1.1.1",
@@ -7262,7 +7262,7 @@
         "memoizee": "^0.4.14",
         "oas-normalize": "^8.3.0",
         "openapi-types": "^12.1.0",
-        "path-to-regexp": "^6.2.0"
+        "path-to-regexp": "6.3.0"
       }
     },
     "oas-kit-common": {
@@ -7472,9 +7472,9 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
     "path-to-regexp": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-      "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="
     },
     "pathval": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,9 @@
     "typescript": "^4.9.5",
     "unique-temp-dir": "^1.0.0"
   },
+  "overrides": {
+    "path-to-regexp@6.2.1": "6.3.0"
+  },
   "prettier": "@readme/eslint-config/prettier",
   "nyc": {
     "exclude": [


### PR DESCRIPTION
JIRA: [SRE-1401](https://auditboard.atlassian.net/browse/SRE-1401)

### Changes

Fixes [vulnerability in path-to-regexp](https://github.com/advisories/GHSA-9wv6-86v2-598j).

`path-to-regexp`:  6.2.1 -> 6.3.0

[SRE-1401]: https://auditboard.atlassian.net/browse/SRE-1401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ